### PR TITLE
Fix issue with aside element text in Anki's dark mode

### DIFF
--- a/anki-cards/style.css
+++ b/anki-cards/style.css
@@ -73,6 +73,7 @@ aside {
     padding-left: 2em;
     padding-right: 0.3em;
     text-indent: -1.3em;
+    color: black;
 }
 aside::before {
     content: '\261E';  /* the pointy grammar hand */


### PR DESCRIPTION
# Overview

In Anki's dark mode, the default text colors changes to white, which doesn't work for the `<aside>` elements since their background is lighter.

## Fix

Explicitly set the text color in asides to black.

## Example

This is the back of the card for `na`

### Before

<img width="411" alt="image" src="https://github.com/user-attachments/assets/39cfbdc4-7c65-4a54-8cf1-6bec5b9f860f" />

### After

<img width="410" alt="image" src="https://github.com/user-attachments/assets/6bd1334a-d23d-4dca-8c9e-79659c146666" />
